### PR TITLE
Vz330 Mellow Kit: Added some details on the contents, squashed some typos

### DIFF
--- a/docs/vz330_mellow/preparation.md
+++ b/docs/vz330_mellow/preparation.md
@@ -214,5 +214,5 @@ The following parts are included in the kit:
 The STLs for the printed parts you need to build the kit are linked in the corresponding part of the build manual. <br/>
 They are shown as a build plate, you are able to click every object there and the corresponding <br/>
 You can also grab them as a zipped archive from the [Vz330 repository](https://github.com/VzBoT3D/VzBoT-Vz330/tree/master/Assemblies%20BOM%20and%20STL/Mellow%20kit-All%20STLs).<br/>
-For info on the optimal print settings for VzBot parts, check out the [Printed Parts](./vz330_printed/printed_parts) guide.<br/>
+For info on the optimal print settings for VzBot parts, check out the [Printed Parts](/vz330_printed/printed_parts) guide.<br/>
 STL should open. The actual number you need to print of the part is the same shown in the picture.

--- a/docs/vz330_mellow/preparation.md
+++ b/docs/vz330_mellow/preparation.md
@@ -17,7 +17,7 @@ permalink: /vz330_mellow/preparation
 You will need the following tools to build up your VzBoT330 from a Mellow kit:
 
 * 1-4mm hex keys
-* A 5.5mm hex socket bit (or pliers to hold a nut in place
+* 5.5mm and 7mm hex socket bits (or pliers to hold a nut in place)
 * Crimping tools for JST connectors, ferrules and cable lugs
 * A soldering iron
 * 99% isopropyl alcohol for cleaning the linear rails

--- a/docs/vz330_mellow/preparation.md
+++ b/docs/vz330_mellow/preparation.md
@@ -14,7 +14,7 @@ permalink: /vz330_mellow/preparation
 
 ## Tools
 
-You will need the following tools to build up your VzBoT330 from a mellow kit:
+You will need the following tools to build up your VzBoT330 from a Mellow kit:
 
 * 1-4mm hex keys
 * A 5.5mm hex socket bit (or pliers to hold a nut in place
@@ -51,8 +51,8 @@ The following parts are included in the kit:
     - NEMA 17 Motor ( LDO )
     - GT2 20teeth idler
     - Stepper motor cable
-    - 4 x Linear Shaft 10mm ( 500 mm )
-    - 2 x Leadscrew 8mm + Nut ( 500 mm )
+    - 4 x Linear Shaft 10mm ( 500mm )
+    - 2 x Leadscrew 8mm + Nut ( 500mm )
     - 4 x Top Rod mounts
     - 4 x LMK10LUU
     - 2 x Upper bracket ( with preinstalled bearing )
@@ -91,26 +91,26 @@ The following parts are included in the kit:
 
 - **VZ330 Box 1**
     - USB Cable
-    - Mellow Super Fly Pro
+    - Mellow Fly Super 8 Pro
     - JST Crimps
     - Jumpers / Fuses / Connectors
 
 - **VZ330 Box 2**
-    - 2 x TMC2209
+    - 2 x TMC2209 stepper drivers
     - Endstop holder z / y
     - Z Chain holder
-    - 4 x Bed - springs
-    - Z Gate belt
+    - 4 x Bed springs
+    - Z Gates GT2 belt loop
     - 3 x Microswitches ( Endstops )
     - 2 x 40 teeth GT Idlers
-    - X/Y Gate belt
+    - X/Y Gates GT2 belt
     - SSR
-    - Main volatage cables ( pre crimped )
+    - Mains voltage cables ( pre-crimped )
     - 4x Rubber feet
 
 - **VZ330 Box 3**
-    - Main Inlet
-    - Power cord
+    - IEC 60320 C14 Mains Inlet
+    - IEC 60320 C13 Power cord
 
 - **VZ330 Box 4**
     - 2 x TMC5160HV

--- a/docs/vz330_mellow/preparation.md
+++ b/docs/vz330_mellow/preparation.md
@@ -14,27 +14,37 @@ permalink: /vz330_mellow/preparation
 
 ## Tools
 
-The following tool's you will need to build up your VzBoT330 from a mellow kit:
+You will need the following tools to build up your VzBoT330 from a mellow kit:
 
-* Tool 1
-* Tool 2
-* Tool 3
+* 1-4mm hex keys
+* A 5.5mm hex socket bit (or pliers to hold a nut in place
+* Crimping tools for JST connectors, ferrules and cable lugs
+* A soldering iron
+* 99% isopropyl alcohol for cleaning the linear rails
+* A synthetic lithium- or PTFE-based lubricant for lubricating the linear rails
+* TBD
+
+Optionally you might want to have the following additional tools ready:
+
+* A drill with a 3mm metal drill bit (if you want to drill holes to mount the DIN rails for the electronics using screws)
+* An M4 tap (if you want to cut threads in those mounting holes)
+* Haribo bears
 
 ## Content
 
-The following part's are included in the kit
+The following parts are included in the kit:
 
 ### Parts
 - **Frame**
-    - 4 x 2040 Aluminium Profile ( Pretapped on both ends ) - Z ( 530mm )
+    - 4 x 2040 Aluminium Profile ( Pre-tapped on both ends ) - Z ( 530mm )
     - 2 x 2020 Aluminium Profile ( One hole on each end ) - X ( 530mm )
     - 2 x 2020 Aluminium Profile ( One hole on each end ) - Y ( 460 mm )
-    - 2 x 2020 Aluminium Profile ( Tow holes on each end ) - Top cover ( 530mm )
+    - 2 x 2020 Aluminium Profile ( Two holes on each end ) - Top cover ( 530mm )
     - 2 x 2020 Aluminium Profile ( No holes at all ) - Top cover ( 460 mm )
     - 4 x 2020 Aluminium Profile - Top Cover ( 100 mm)
 
 - **Gantry**
-    - Preasambled Gantry with PLA parts
+    - Preassembled Gantry with PLA parts
 
 - **Z**
     - NEMA 17 Motor ( LDO )
@@ -54,7 +64,7 @@ The following part's are included in the kit
     - Aluminium Bed
     - PEI Sheet
     - Magnet
-    - Heater
+    - 750W Silicone Heater
 
 - **Enclosure**
     - Panel Back ( Aluminium )
@@ -95,6 +105,7 @@ The following part's are included in the kit
     - X/Y Gate belt
     - SSR
     - Main volatage cables ( pre crimped )
+    - 4x Rubber feet
 
 - **VZ330 Box 3**
     - Main Inlet
@@ -110,80 +121,83 @@ The following part's are included in the kit
 
 - **VZ330 Box 6**
     - **VZ330 - M2 ( Bag )**
-        - Bagnumber 1/5 - 4 x M2 x 8mm ( Button head )
-        - Bagnumber 2/5 - 4 x M2 x 10mm ( Button head )
-        - Bagnumber 3/5 - 6 x M2.5 x 5mm ( Low profile )
-        - Bagnumber 4/5 - 6 x M2.5 x 6mm ( Low profile )
-        - Bagnumber 5/5 - 6 x M2.6 x 8mm ( Self cutting )
+        - Bag number 1/5 - 4 x M2 x 8mm ( Button head )
+        - Bag number 2/5 - 4 x M2 x 10mm ( Button head )
+        - Bag number 3/5 - 6 x M2.5 x 5mm ( Low profile )
+        - Bag number 4/5 - 6 x M2.5 x 6mm ( Low profile )
+        - Bag number 5/5 - 6 x M2.5 x 8mm ( Self cutting )
     - **VZ330 - M3 ( Bag )**
-        - Bagnumber 1/16 - 60 x M3 t-nuts
-        - Bagnumber 2/16 - 60 x M3 sliding t-nuts
-        - Bagnumber 3/16 - 4 x M3 x 8mm ( Socket head )
-        - Bagnumber 4/16 - 70 x M3 x 10mm ( Socket head )
-        - Bagnumber 5/16 - 20 x M3 x 6mm ( Low profile )
-        - Bagnumber 6/16 - 6 x M3 x 5mm ( Low profile )
-        - Bagnumber 7/16 - 4 x M3 x 8mm ( Low profile )
-        - Bagnumber 8/16 - 6 x M3 x 45mm ( Countersunk )
-        - Bagnumber 9/16 - 4 x M3 x 8mm ( Countersunk )
-        - Bagnumber 10/16 - 4 x M3 x 10mm ( Countersunk )
-        - Bagnumber 11/16 - 4 x M3 washer ( 0.5 )
-        - Bagnumber 12/16 - 26 x M3 nut
-        - Bagnumber 13/16 - 4 x M3 x 25mm ( Button head )
-        - Bagnumber 14/16 - 8 x M3 x 6mm ( Button head )
-        - Bagnumber 15/16 - 4 x M3 x 14mm ( Button head )
-        - Bagnumber 16/16 - 14 x M3 x 10mm ( Button head )
+        - Bag number 1/16 - 60 x M3 t-nuts
+        - Bag number 2/16 - 60 x M3 sliding t-nuts
+        - Bag number 3/16 - 4 x M3 x 8mm ( Socket head )
+        - Bag number 4/16 - 70 x M3 x 10mm ( Socket head )
+        - Bag number 5/16 - 20 x M3 x 6mm ( Low profile )
+        - Bag number 6/16 - 6 x M3 x 5mm ( Low profile )
+        - Bag number 7/16 - 4 x M3 x 8mm ( Low profile )
+        - Bag number 8/16 - 6 x M3 x 45mm ( Countersunk )
+        - Bag number 9/16 - 4 x M3 x 8mm ( Countersunk )
+        - Bag number 10/16 - 4 x M3 x 10mm ( Countersunk )
+        - Bag number 11/16 - 4 x M3 washer ( 0.5 )
+        - Bag number 12/16 - 26 x M3 nut
+        - Bag number 13/16 - 4 x M3 x 25mm ( Button head )
+        - Bag number 14/16 - 8 x M3 x 6mm ( Button head )
+        - Bag number 15/16 - 4 x M3 x 14mm ( Button head )
+        - Bag number 16/16 - 14 x M3 x 10mm ( Button head )
     - **VZ330 - M4 ( Bag )**
-        - Bagnumber 1/16 - 10 x M4 x 12mm ( Self cutting )
-        - Bagnumber 2/16 - 96 x M4 t-nut
-        - Bagnumber 3/16 - 96 x M4 sliding t-nut
-        - Bagnumber 4/16 - 40 x M4 x 10mm ( Socket head )
-        - Bagnumber 5/16 - 6 x M4 x 8mm ( Socket head )
-        - Bagnumber 6/16 - 12 x M4 x 12mm ( Socket head )
-        - Bagnumber 7/16 - 12 x M4 x 16mm ( Socket head )
-        - Bagnumber 8/16 - 14 x M4 x 20mm ( Socket head )
-        - Bagnumber 9/16 - 2 x M4 x 30mm ( Socket head )
-        - Bagnumber 10/16 - 12 x M4 nut
-        - Bagnumber 11/16 - 2 x M4 selflocking nut
-        - Bagnumber 12/16 - 6 x M4 x 20mm ( Button head )
-        - Bagnumber 13/16 - 20 x M4 x 12mm ( Button head )
-        - Bagnumber 14/16 - 26 x M4 x 10mm ( Button head )
-        - Bagnumber 15/16 - 12 x M4 x 8mm ( Button head )
-        - Babnumber 16/16 - 2 x M4 x 30mm ( xxx )
+        - Bag number 1/16 - 10 x M4 x 12mm ( Self cutting )
+        - Bag number 2/16 - 96 x M4 t-nut
+        - Bag number 3/16 - 96 x M4 sliding t-nut
+        - Bag number 4/16 - 40 x M4 x 10mm ( Socket head )
+        - Bag number 5/16 - 6 x M4 x 8mm ( Socket head )
+        - Bag number 6/16 - 12 x M4 x 12mm ( Socket head )
+        - Bag number 7/16 - 12 x M4 x 16mm ( Socket head )
+        - Bag number 8/16 - 14 x M4 x 20mm ( Socket head )
+        - Bag number 9/16 - 2 x M4 x 30mm ( Socket head )
+        - Bag number 10/16 - 12 x M4 nut
+        - Bag number 11/16 - 2 x M4 selflocking nut
+        - Bag number 12/16 - 6 x M4 x 20mm ( Button head )
+        - Bag number 13/16 - 20 x M4 x 12mm ( Button head )
+        - Bag number 14/16 - 26 x M4 x 10mm ( Button head )
+        - Bag number 15/16 - 12 x M4 x 8mm ( Button head )
+        - Bab number 16/16 - 2 x M4 x 30mm ( xxx )
     - **VZ330 - M5 ( Bag )**
-        - Bagnumber 1/6 - 16 x M5 t-nut
-        - Bagnumber 2/6 - 16 x M5 sliding t-nut 
-        - Bagnumber 3/6 - 14 x M5 x 8mm ( Socket head )
-        - Bagnumber 4/6 - 10 x M5 x 25mm ( Socket head )
-        - Bagnumber 5/6 - 6 x M5 x 35mm ( Socket head )
-        - Bagnumber 6/6 - 10 x M5 x 10mm ( Socket head )
+        - Bag number 1/6 - 16 x M5 t-nut
+        - Bag number 2/6 - 16 x M5 sliding t-nut 
+        - Bag number 3/6 - 14 x M5 x 8mm ( Socket head )
+        - Bag number 4/6 - 10 x M5 x 25mm ( Socket head )
+        - Bag number 5/6 - 6 x M5 x 35mm ( Socket head )
+        - Bag number 6/6 - 10 x M5 x 10mm ( Socket head )
     - **VZ330 - Others**
-        - Bagnumber 1/4 - 6 x 2020 Corner pieces
-        - Bagnumber 2/4 - 10 x Magnet ( 5 x 2mm )
-        - Bagnumber 3/4 - 2 x 4 x 50mm ( xxx )
-        - Bagnumber 4/4 - 2x 5 x 50mm ( xxx )
+        - Bag number 1/4 - 6 x 2020 Corner pieces
+        - Bag number 2/4 - 10 x Magnet ( 5 x 2mm )
+        - Bag number 3/4 - 2 x 4 x 50mm ( xxx )
+        - Bag number 4/4 - 2x 5 x 50mm ( xxx )
 
 - **VZ330 Box 7**
-    - Main wires
+    - Mains wires
     - Hotend wires
     - Endstop wires
 
 - **VZ330 Box A**
     - Display
+    - DSI adapter PCB for the display
+    - DSI ribbon cable
 
 - **VZ330 Box B**
     - CPAP Fan
-    - ....
+    - CPAP Fan controller board
+    - CPAP Fan wiring
 
 - **VZ330 Box C**
-    - VzExtrudor with 10 teeth moon stepper
+    - Vz-HextrudORT with 8-10 teeth Moons' or LDO 36mm pancake stepper motor
     - Goliath hotend
     - Aluminium printhead parts
     - Nozzle
-    - Thermistor ( M3 )
+    - PT-1000 Screw-in Thermistor ( M3 )
 
 - **VZ330 Box D**
-    - 4 x Fan xxxx
-    - 1 x Fan xxxx
+    - 4 x Fan 40x10mm for stepper driver cooling
+    - 1 x Fan 25x10mm for printhead cooling
 
 ## Parts to self source
 
@@ -194,8 +208,10 @@ The following part's are included in the kit
 - Thermal Fuse ( link1 / link2 )
 
 
-## STL's
+## STLs
 
-The STL's you need to build the kit are linked in the corresponding part of the build manual. <br/>
+The STLs for the printed parts you need to build the kit are linked in the corresponding part of the build manual. <br/>
 They are shown as a build plate, you are able to click every object there and the corresponding <br/>
+You can also grab them as a zipped archive from the [Vz330 repository](https://github.com/VzBoT3D/VzBoT-Vz330/tree/master/Assemblies%20BOM%20and%20STL/Mellow%20kit-All%20STLs).<br/>
+For info on the optimal print settings for VzBot parts, check out the [Printed Parts](./vz330_printed/printed_parts) guide.<br/>
 STL should open. The actual number you need to print of the part is the same shown in the picture.

--- a/docs/vz330_mellow/preparation.md
+++ b/docs/vz330_mellow/preparation.md
@@ -28,6 +28,7 @@ Optionally you might want to have the following additional tools ready:
 
 * A drill with a 3mm metal drill bit (if you want to drill holes to mount the DIN rails for the electronics using screws)
 * An M4 tap (if you want to cut threads in those mounting holes)
+* A carpenter's square can come in really handy when squaring the printer frame
 * Haribo bears
 
 ## Content


### PR DESCRIPTION
Hi there!

As I'm starting out my Vz330 kit build, I hope, me adding some of my findings to the documentation is welcome. I couldn't find a contribution guide, so I just forked the repo and got going. For starters, I did a small pass over the Preparations section for the kit, suished some typos and added some details on the contents of the kit. I also took the liberty of adding some tools to the list of required tools as an incomplete list is still better than a pure placeholder.

In the STLs section I took the liberty of adding backlinks to the Mellow kit STL zipped archive as well as the printed parts guide to point people to where they can get the STLs and where they can print them once more.

Notes:
* I added lubricant for the rails to the required tools list. I've only referred to generic Lithium- or PTFE-based stuff as that gives a "safe" baseline. It might be helpful to point builders to a selection of recommended lubricants. There is a whole channel on your Discord dedicated to the rites and worship of the linear rail who might have input on this, but I did not dare ask for fear of conjuring up a holy war ;)
* My Vz-HextrudORT came with a 10T LDO 36STH20-1004AHG rather than a Moons'. I also asked Mellow for the watercooled version. From their Aliexpress site, it seems like Mellow does regularly outfit the extruder with either motor in either 8T or 10T variants. So until there's confirmation from Mellow on what motors one can expect, I've added all variants to the contents.