### PR TITLE
Add bundler to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 _site/
+.bundle/config
+vendor/bundle/


### PR DESCRIPTION
This allows you to use local AND non-root deployment from your local machine. ; Execute `bundle config set --local path 'vendor/bundle'` in the terminal to use Bundler in the local directory (without root permission).