### PR TITLE
Redirect from old section indexes

### DIFF
--- a/docs/vz235_mellow/RSCS.md
+++ b/docs/vz235_mellow/RSCS.md
@@ -6,6 +6,8 @@ has_toc: false
 nav_order: 7
 has_children: false
 permalink: /vz235_mellow/rscs
+redirect_from:
+  - /vz235_alu/rscs
 ---
 
 # 7. Side panels + RSCS

--- a/docs/vz235_mellow/bottom_panels.md
+++ b/docs/vz235_mellow/bottom_panels.md
@@ -6,6 +6,8 @@ has_toc: false
 nav_order: 4
 has_children: false
 permalink: /vz235_mellow/panels_part1
+redirect_from:
+  - /vz235_alu/panels_part1
 ---
 
 # 4. Bottom and rear panels

--- a/docs/vz235_mellow/electronics.md
+++ b/docs/vz235_mellow/electronics.md
@@ -6,6 +6,8 @@ has_toc: false
 nav_order: 6
 has_children: true
 permalink: /vz235_mellow/electronics
+redirect_from:
+  - /vz235_alu/electronics
 ---
 
 # 6. Electronics

--- a/docs/vz235_mellow/frame.md
+++ b/docs/vz235_mellow/frame.md
@@ -6,6 +6,8 @@ has_toc: false
 nav_order: 1
 has_children: false
 permalink: /vz235_mellow/frame
+redirect_from:
+  - /vz235_alu/frame
 ---
 
 # 1. Frame

--- a/docs/vz235_mellow/fume.md
+++ b/docs/vz235_mellow/fume.md
@@ -6,6 +6,8 @@ has_toc: false
 nav_order: 5
 has_children: false
 permalink: /vz235_mellow/fume_extractor
+redirect_from:
+  - /vz235_alu/fume_extractor
 ---
 
 # 5. Fume extractor

--- a/docs/vz235_mellow/gantry.md
+++ b/docs/vz235_mellow/gantry.md
@@ -6,6 +6,8 @@ has_toc: false
 nav_order: 3
 has_children: true
 permalink: /vz235_mellow/gantry
+redirect_from:
+  - /vz235_alu/gantry
 ---
 
 # 3. Gantry

--- a/docs/vz235_mellow/index.md
+++ b/docs/vz235_mellow/index.md
@@ -5,6 +5,9 @@ has_toc: false
 nav_order: 6
 has_children: true
 permalink: /vz235_mellow
+redirect_from:
+  - /vz235_alu
+  - /vz235_alu/
 ---
 
 # VzBoT 235 - Mellow Kit

--- a/docs/vz235_mellow/top_cover.md
+++ b/docs/vz235_mellow/top_cover.md
@@ -6,6 +6,8 @@ has_toc: false
 nav_order: 8
 has_children: true
 permalink: /vz235_mellow/top_cover
+redirect_from:
+  - /vz235_alu/top_cover
 ---
 
 # 8. Top cover and doors panels

--- a/docs/vz235_mellow/z_assembly_bed.md
+++ b/docs/vz235_mellow/z_assembly_bed.md
@@ -6,6 +6,8 @@ has_toc: false
 nav_order: 2
 has_children: true
 permalink: /vz235_mellow/z_assembly
+redirect_from:
+  - /vz235_alu/z_assembly
 ---
 
 # 2. Z - Assembly & Bed


### PR DESCRIPTION
This ammends the previous Alu to Mellow edits with extra redirects from the old pages