### PR TITLE
Add warning about DSI screen issues

### DIFF
--- a/docs/vz235_mellow/electronics/Firmware.md
+++ b/docs/vz235_mellow/electronics/Firmware.md
@@ -13,6 +13,14 @@ permalink: /vz235_mellow/electronics/Firmware
 
 Time to start flashing our Pi and Motherboard.
 
+{: .note-title }
+> DSI touch screen issues
+>
+> There is a known issue with the Vz235 Mellow kit touch screen.
+> More info and fixes: [Touch not working - KlipperScreen][] 
+
+[Touch not working - KlipperScreen]: https://klipperscreen.readthedocs.io/en/latest/Troubleshooting/Touch_issues/
+
 ## Flashing the Pi
 
 Take your Pi's SDCard and put it in your PC/laptop. Now we're gonna use the program called Raspberry Pi Imager to flash the firmware for it onto our SDCard. You can get it here [Raspberry Pi Imager](https://www.raspberrypi.com/software/)
@@ -221,3 +229,5 @@ If klippy.log reports a "Permission denied" error when attempting to connect to 
 ```bash
 sudo usermod -a -G tty pi
 ```
+
+[Touch not working - KlipperScreen]: https://klipperscreen.readthedocs.io/en/latest/Troubleshooting/Touch_issues/

--- a/docs/vz235_printed/electronics/Firmware.md
+++ b/docs/vz235_printed/electronics/Firmware.md
@@ -13,6 +13,14 @@ permalink: /vz235_printed/electronics/Firmware
 
 Time to start flashing our Pi and Motherboard.
 
+{: .note-title }
+> DSI touch screen issues
+>
+> There is a known issue with touch screens like those used in the Vz235 Mellow kit.
+> More info and fixes: [Touch not working - KlipperScreen][]
+
+[Touch not working - KlipperScreen]: https://klipperscreen.readthedocs.io/en/latest/Troubleshooting/Touch_issues/
+
 ## Flashing the Pi
 
 Take your Pi's SDCard and put it in your PC/laptop. Now we're gonna use the program called Raspberry Pi Imager to flash the firmware for it onto our SDCard. You can get it here [Raspberry Pi Imager](https://www.raspberrypi.com/software/)

--- a/docs/vz330_mellow/electronics/firmware.md
+++ b/docs/vz330_mellow/electronics/firmware.md
@@ -16,7 +16,7 @@ Time to start flashing our Pi and Motherboard.
 {: .note-title }
 > DSI touch screen issues
 >
-> There is a known issue with the Vz235 Mellow kit touch screen.
+> There is a known issue with the Vz330 Mellow kit touch screen.
 > More info and fixes: [Touch not working - KlipperScreen][]
 
 [Touch not working - KlipperScreen]: https://klipperscreen.readthedocs.io/en/latest/Troubleshooting/Touch_issues/

--- a/docs/vz330_mellow/electronics/firmware.md
+++ b/docs/vz330_mellow/electronics/firmware.md
@@ -13,6 +13,14 @@ permalink: /vz330_mellow/electronics/Firmware
 
 Time to start flashing our Pi and Motherboard.
 
+{: .note-title }
+> DSI touch screen issues
+>
+> There is a known issue with the Vz235 Mellow kit touch screen.
+> More info and fixes: [Touch not working - KlipperScreen][]
+
+[Touch not working - KlipperScreen]: https://klipperscreen.readthedocs.io/en/latest/Troubleshooting/Touch_issues/
+
 ## Flashing the Pi
 
 Take your Pi's SDCard and put it in your PC/laptop. Now we're gonna use the program called Raspberry Pi Imager to flash the firmware for it onto our SDCard. You can get it here [Raspberry Pi Imager](https://www.raspberrypi.com/software/)


### PR DESCRIPTION
Add warning about DSI screen issues on Raspberry Pi OS (a fork of Debian)

Affected pages:

- https://docs.vzbot.org/vz330_mellow/electronics/Firmware
- https://docs.vzbot.org/vz235_printed/electronics/Firmware
- https://docs.vzbot.org/vz235_mellow/electronics/Firmware

Addresses issue [`#69` Touch on DSI touchscreens may not work with Raspberry Pis due to kernel driver issue](https://github.com/VzBoT3D/docs/issues/69)