### PR TITLE
Hide scrollbar when the side-nav expands (etc)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,12 +25,13 @@ GEM
     ethon (0.16.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
-    execjs (2.9.0)
+    execjs (2.9.1)
     faraday (2.7.11)
       base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
+    ffi (1.15.5)
     ffi (1.15.5-x64-mingw-ucrt)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
@@ -234,6 +235,8 @@ GEM
     minitest (5.20.0)
     nokogiri (1.15.4-x64-mingw-ucrt)
       racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-linux)
+      racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -277,6 +280,7 @@ GEM
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
+    unf_ext (0.0.8.2)
     unf_ext (0.0.8.2-x64-mingw-ucrt)
     unicode-display_width (1.8.0)
     wdm (0.1.1)
@@ -285,6 +289,7 @@ GEM
 
 PLATFORMS
   x64-mingw-ucrt
+  x86_64-linux
 
 DEPENDENCIES
   github-pages

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -82,3 +82,15 @@
     }
   }
   /***** END Homepage styling*****/
+
+// Hide the side nav scrollbar when the contents overflow it verticallybundler 
+.site-nav {
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  
+  @include mq(md) {
+   -ms-overflow-style: none;  /* IE and Edge Hide scrollbar*/
+    scrollbar-width: none;  /* Firefox Hide scrollbar*/
+  }
+}


### PR DESCRIPTION
PR #78 introduced a couple issues that weren't fixed before merging:

Fix a platform issue (zerog-fixes)
reimplement a feature that was removed during cleanup (zerog-fixes)

This cherry picks from the original gh-pages branch.