### PR TITLE
Bump dependency to resolve security vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,10 +34,13 @@ gem "jekyll-include-cache"
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.
 install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do
-  gem "tzinfo", "~> 1.2"
+  gem "tzinfo"
   gem "tzinfo-data"
 end
 
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 gem "webrick", "~> 1.7"
+
+# Forced version requirement due to security vulnerability
+gem 'activesupport', '~> 7.0', '>= 7.0.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.6.1)
+    activesupport (7.0.8)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     base64 (0.1.1)
@@ -214,7 +213,7 @@ GEM
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    just-the-docs (0.6.1)
+    just-the-docs (0.6.2)
       jekyll (>= 3.8.5)
       jekyll-include-cache
       jekyll-seo-tag (>= 2.0)
@@ -228,14 +227,14 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
+    mini_portile2 (2.8.4)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.20.0)
-    nokogiri (1.15.4-x64-mingw-ucrt)
-      racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-linux)
+    nokogiri (1.15.4)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -270,28 +269,26 @@ GEM
     temple (0.8.2)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    thread_safe (0.3.6)
     tilt (2.0.11)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.11)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     tzinfo-data (1.2023.3)
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    unf_ext (0.0.8.2-x64-mingw-ucrt)
     unicode-display_width (1.8.0)
     wdm (0.1.1)
     webrick (1.8.1)
-    zeitwerk (2.6.11)
 
 PLATFORMS
   x64-mingw-ucrt
   x86_64-linux
 
 DEPENDENCIES
+  activesupport (~> 7.0, >= 7.0.8)
   github-pages
   jekyll-include-cache
   jekyll-redirect-from
@@ -301,7 +298,7 @@ DEPENDENCIES
   jekyll_bootstrap5_tabs
   just-the-docs
   kramdown-parser-gfm
-  tzinfo (~> 1.2)
+  tzinfo
   tzinfo-data
   wdm (~> 0.1.1)
   webrick (~> 1.7)

--- a/docs/general/index.md
+++ b/docs/general/index.md
@@ -1,0 +1,13 @@
+---
+title: General info
+description: General information index
+tags:
+  - general info
+  - info
+  - tuning
+  - maintenance
+  - printer
+  - setup
+has_children: true
+nav_order: 
+---

--- a/docs/general/maintenance.md
+++ b/docs/general/maintenance.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Maintenance
-parent: misc-info # temporarily here to clean up the sidebar links
+parent: General info # temporarily here to clean up the sidebar links
 ---
 
 # Printer maintenance

--- a/docs/general/misc-info/tuning.md
+++ b/docs/general/misc-info/tuning.md
@@ -1,0 +1,3 @@
+---
+parent: Miscellaneous info
+---

--- a/docs/general/troubleshooting.md
+++ b/docs/general/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Maintenance
-parent: misc-info # temporarily here to clean up the sidebar links
+parent: General info # temporarily here to clean up the sidebar links
 ---
 
 # Troubleshooting
@@ -10,15 +10,12 @@ Troubleshoot common problems with your printer
 
 ## Printer homes in the wrong corner
 
-<<<<<<< HEAD
 Ensure your stepper motors are set up to rotate in the correct direction.  
 [\[Stepper\] - Configuration reference](https://www.klipper3d.org/Config_Reference.html#stepper) (Klipper docs)
 
 Ensure the endstop positions for all axes are set correctly.  
 See `position_endstop:` under your `[stepper]` configuration section.
 
-=======
->>>>>>> b9a94e9f1a7ddb0830a97d54fbee0f9745e9c60e
 ## Prints are mirrored
 
 You most likely have your motors set up wrong or mirrored. Make sure the physical motors match their counterpart configuration in your `printer.cfg` configuration file.

--- a/docs/general/which-vzbot.md
+++ b/docs/general/which-vzbot.md
@@ -1,7 +1,7 @@
 ---
 title: Which VzBot do I want?
 description: A guided choice on which VzBot printer is best for you
-parent: misc-info # temporarily here to clean up the sidebar links
+parent: General info # temporarily here to clean up the sidebar links
 ---
 
 


### PR DESCRIPTION
Dependabot couldn't create a PR for `activesupport` due to a version lock on `tzinfo` the gemfile.

After checking why the version was locked, I couldn't determine any reason why `tzinfo` shouldn't be updated to the latest, or at least the version required by the newer `activesupport` packages where the security vulnerability was fixed.

A deployment on my local machine with `bundle exec jekyll serve -s ./docs -V` (verbose build) shows no issues. 