### PR TITLE
Printer config fixes

### DIFF
--- a/docs/assets/images/manual/vz235_printed/electronics/Printer_config/printer.cfg
+++ b/docs/assets/images/manual/vz235_printed/electronics/Printer_config/printer.cfg
@@ -212,9 +212,9 @@ sensor_type: PT1000
 sensor_pin: PF4
 
 #control: pid
-#pid_Kp=28.737 
-#pid_Ki=1.935 
-#pid_Kd=106.684
+pid_Kp: 28.737 
+pid_Ki: 1.935 
+pid_Kd: 106.684
 min_temp: 0
 max_temp: 400
 full_steps_per_rotation: 200
@@ -239,10 +239,10 @@ sense_resistor: 0.110
 heater_pin: PE5
 sensor_type: Generic 3950
 sensor_pin: PC1
-#control: pid
-#pid_Kp: 66.746
-#pid_Ki: 3.504
-#pid_Kd: 317.878
+control: pid
+pid_Kp: 66.746
+pid_Ki: 3.504
+pid_Kd: 317.878
 min_temp: 0
 max_temp: 130
 

--- a/docs/assets/images/manual/vz330_mellow/electronics/Printer_config/printer.cfg
+++ b/docs/assets/images/manual/vz330_mellow/electronics/Printer_config/printer.cfg
@@ -212,10 +212,10 @@ heater_pin: PB0
 sensor_type: PT1000
 sensor_pin: PF4
 
-#control: pid
-#pid_Kp=28.737 
-#pid_Ki=1.935 
-#pid_Kd=106.684
+control: pid
+pid_Kp=28.737 
+pid_Ki=1.935 
+pid_Kd=106.684
 min_temp: 0
 max_temp: 400
 full_steps_per_rotation: 200
@@ -240,10 +240,10 @@ sense_resistor: 0.110
 heater_pin: PE5
 sensor_type: Generic 3950
 sensor_pin: PC1
-#control: pid
-#pid_Kp: 66.746
-#pid_Ki: 3.504
-#pid_Kd: 317.878
+control: pid
+pid_Kp: 66.746
+pid_Ki: 3.504
+pid_Kd: 317.878
 min_temp: 0
 max_temp: 130
 

--- a/docs/assets/images/manual/vz330_mellow/electronics/Printer_config/printer.cfg
+++ b/docs/assets/images/manual/vz330_mellow/electronics/Printer_config/printer.cfg
@@ -213,9 +213,9 @@ sensor_type: PT1000
 sensor_pin: PF4
 
 control: pid
-pid_Kp=28.737 
-pid_Ki=1.935 
-pid_Kd=106.684
+pid_Kp: 28.737 
+pid_Ki: 1.935 
+pid_Kd: 106.684
 min_temp: 0
 max_temp: 400
 full_steps_per_rotation: 200

--- a/docs/vz330_mellow/electronics/Printer Config.md
+++ b/docs/vz330_mellow/electronics/Printer Config.md
@@ -14,7 +14,7 @@ permalink: /vz330_mellow/electronics/Printer_Config
 Now comes the fun part of the setup. Configuring your printer.cfg.
 
 We're gonna start with this basic start config file for you guys to use:
-[Printer.cfg](../../assets\images\manual\vz330_mellow\electronics\Printer_config\printer.cfg)
+[Printer.cfg](../../assets/images/manual/vz330_mellow/electronics/Printer_config/printer.cfg)
 
 In order to use the Exlcude object command in your Mainsail or Fluid we're also gonna need this file: [Exclude_Object.cfg](../../assets/images/manual/vz235_printed/electronics/Printer_config/Exclude_Object.cfg)
 


### PR DESCRIPTION
This incorporates all changes from the previous one, but we're doing it anew because the previous one had a lot of issue junk in it.

Changes in the previous PR:

Excluding ones that weren't meant to be there

- Fixed a broken link to printer.cfg on the config document pages
- Integrate Pbsuper's changes that enable PID settings by default on the vz330 config
- Fixed Pbsuper's PID settings to follow the format of the general config file (equals to colon)


Changes since last PR:

- Enabled the PID changes pbsuper made on both printers, not just the Vz330 ([de2a42d](https://github.com/VzBoT3D/docs/pull/87/commits/de2a42df3c2f9ca39b7b997cc2a9ac63a39ec22c))