### PR TITLE
Ignore more Jekyll changes and editor artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,16 +2,21 @@
 CNAME
 
 # Bundler / Ruby / Jekyll
+Gemfile.lock
 .bundle/config
 vendor/bundle/
 
 # Jekyll build output
 _site/
 .sass-cache
+docs/.jekyll-cache
 docs/.jekyll-metadata
 
 # VSCode user-specific files
 .vscode/settings.json
+
+# Vim <3
+*.swp
 
 # MacOS metadata file
 **/.DS_Store 


### PR DESCRIPTION
Because clean and for the love of vim (and using vanilla vim in places).

This also masks Gemfile.lock; this is to ensure bundle making changes do not accidentally end up being pushed without forcing it.