### PR TITLE
Topic screen docs urls links

### DIFF
--- a/docs/vz235_mellow/electronics/Touchscreen.md
+++ b/docs/vz235_mellow/electronics/Touchscreen.md
@@ -3,10 +3,8 @@ layout: default
 title: 6.5 Touchscreen
 parent: 6. Electronics
 grand_parent: Vz235 - Mellow Kit
-has_toc: false
 nav_order: 5
-has_children: false
-permalink: /vz235_mellow/electronics/Touchscreen
+slug: touchscreen
 ---
 # Touchscreen Assembly and Installation.
 

--- a/docs/vz235_mellow/electronics/Touchscreen.md
+++ b/docs/vz235_mellow/electronics/Touchscreen.md
@@ -5,6 +5,7 @@ parent: 6. Electronics
 grand_parent: Vz235 - Mellow Kit
 nav_order: 5
 slug: touchscreen
+redirect_from: Touchscreen
 ---
 # Touchscreen Assembly and Installation.
 

--- a/docs/vz235_printed/electronics/Touchscreen.md
+++ b/docs/vz235_printed/electronics/Touchscreen.md
@@ -3,10 +3,8 @@ layout: default
 title: 6.5 Touchscreen
 parent: 6. Electronics
 grand_parent: Vz235 - Printed Version
-has_toc: false
 nav_order: 5
-has_children: false
-permalink: /vz235_printed/electronics/Touchscreen
+slug: touchscreen
 ---
 # Touchscreen Assembly and Installation.
 

--- a/docs/vz235_printed/electronics/Touchscreen.md
+++ b/docs/vz235_printed/electronics/Touchscreen.md
@@ -5,6 +5,7 @@ parent: 6. Electronics
 grand_parent: Vz235 - Printed Version
 nav_order: 5
 slug: touchscreen
+redirect_from: Touchscreen
 ---
 # Touchscreen Assembly and Installation.
 

--- a/docs/vz330_mellow/electronics/Touchscreen.md
+++ b/docs/vz330_mellow/electronics/Touchscreen.md
@@ -5,6 +5,7 @@ parent: 6. Electronics
 grand_parent: Vz330 - Mellow Kit
 nav_order: 6
 slug: touchscreen
+redirect_from: Touchscreen
 ---
 
 # Touchscreen Assembly and Installation.

--- a/docs/vz330_mellow/electronics/Touchscreen.md
+++ b/docs/vz330_mellow/electronics/Touchscreen.md
@@ -6,7 +6,7 @@ grand_parent: Vz330 - Mellow Kit
 has_toc: false
 nav_order: 6
 has_children: false
-permalink: /vz330_mellow/electronics/Touschreen
+permalink: /vz330_mellow/electronics/Touchscreen
 ---
 
 # Touchscreen Assembly and Installation.

--- a/docs/vz330_mellow/electronics/Touchscreen.md
+++ b/docs/vz330_mellow/electronics/Touchscreen.md
@@ -3,10 +3,8 @@ layout: default
 title: 6.6 Touchscreen
 parent: 6. Electronics
 grand_parent: Vz330 - Mellow Kit
-has_toc: false
 nav_order: 6
-has_children: false
-permalink: /vz330_mellow/electronics/Touchscreen
+slug: touchscreen
 ---
 
 # Touchscreen Assembly and Installation.


### PR DESCRIPTION
[Touchscreen doc permalink](https://github.com/VzBoT3D/docs/commit/81cb2b65b724ed86a3dae67ba9b6a5825e3060b9) 


[Capitalisation of files and slugs](https://github.com/VzBoT3D/docs/commit/3a97ea8b933827d547f10c5d9447886f6d7a3984)

[Backwards compatibility redirect](https://github.com/VzBoT3D/docs/commit/bef773caf10cadd44e621d5909a84a86a137d7ba)

Permalink to Touchscreen doc page for vz330mellow was misspelled. Corrected Touschreen to Touchscreen.
So much for knowing you get things right 😅 /nhf