### PR TITLE
Fix Maintenance button URL/link

### DIFF
--- a/docs/general/troubleshooting/index.md
+++ b/docs/general/troubleshooting/index.md
@@ -39,4 +39,4 @@ Ensure your printer is not set up to use StealthChop. SpreadCycle is preferred, 
 * [Tuning motor current - TMC drivers](https://www.klipper3d.org/TMC_Drivers.html?h=sensorless#tuning-motor-current) (Klipper docs)
 * [Setting "spreadCycle" vs "stealthChop" Mode - TMC drivers](https://www.klipper3d.org/TMC_Drivers.html?h=sensorless#setting-spreadcycle-vs-stealthchop-mode) (Klipper docs)
 
-[**Next:** Maintenance &rarr;](./maintenance){: .btn .btn-doc}
+[**Next:** Maintenance &rarr;](../maintenance){: .btn .btn-doc}


### PR DESCRIPTION
The relative link pointed at the wrong destination. This commit fixes this.