### PR TITLE
Fix a few issues in the STL to print tables

### DIFF
--- a/docs/vz235_mellow/bottom_panels.md
+++ b/docs/vz235_mellow/bottom_panels.md
@@ -56,5 +56,5 @@ Mount the feet and all hardware to the bottom panel. Next up mount the bottom pa
 
 ![Step 3](../assets/images/manual/vz235_printed/panels_1/step_3.png)
 
-[VzBoT Foot]: https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl
-[Foot scalable spacer]: https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl
+[VzBoT Foot]: https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Feet/STL/foot.stl
+[Foot scalable spacer]: https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Feet/STL/Spacer.stl

--- a/docs/vz235_mellow/gantry/printhead.md
+++ b/docs/vz235_mellow/gantry/printhead.md
@@ -33,11 +33,11 @@ In this section we'll assemble the Toolhead for the VzBot.
 | <a href="https://github.com/VzBoT3D/Vz-Printhead-CNC/blob/main/STLs/cable_holder.stl" target="_blank">Cable Holder</a> | 1 | - |
 | <a href="https://github.com/VzBoT3D/Vz-Printhead-CNC/blob/main/STLs/fan%20duct%20lower%20Goliath%20long.stl" target="_blank">Fan duct Goliath</a> | 1 | Pick this if no beacon is used |
 | <a href="https://github.com/VzBoT3D/Vz-Printhead-CNC/blob/main/STLs/fan%20duct%20lower%20Goliath%20short%20with%20Beacon.stl" target="_blank">Fan duct Goliath ( beacon )</a> | 1 | Use this duct for Goliath and beacon |
-| <a href="https://github.com/VzBoT3D/Vz-Printhead-CNC/blob/main/STLs/fan%20duct%20lower%20Goliath%20spacers.stl" target="_blank">Fan duct Goliath spacers</a> | 1 | - |
+| <a href="https://github.com/VzBoT3D/Vz-Printhead-CNC/blob/main/STLs/fan%20duct%20lower%20Goliath%20spacers.stl" target="_blank">Fan duct Goliath spacers</a> | 2 | - |
 | <a href="https://github.com/VzBoT3D/Vz-Printhead-CNC/blob/main/STLs/CPAP%20turbo%20cooling%20system/STLs/upper%20duct.stl" target="_blank">Fan duct upper</a> | 1 | - |
 | <a href="https://github.com/VzBoT3D/Vz-Printhead-CNC/blob/main/STLs/CPAP%20turbo%20cooling%20system/STLs/upper%20duct%20mount.stl" target="_blank">Upper duct mount</a> | 1 | - |
-| <a href="https://github.com/VzBoT3D/Vz-Printhead-CNC/blob/main/STLs/CPAP%20turbo%20cooling%20system/STLs/c-clamp.stl" target="_blank">Upper duct cpcp c clamp</a> | 1 | - |
-| <a href="https://github.com/VzBoT3D/Goliath/blob/main/STL/Air%20Cool%20Fan%20duct/Fan%20duct%202510-With%20flange%20for%20Vz-Printhead%20CNC.stl" target="_blank">Goliath 2410 fan duct</a> | 1 | - |
+| <a href="https://github.com/VzBoT3D/Vz-Printhead-CNC/blob/main/STLs/CPAP%20turbo%20cooling%20system/STLs/c-clamp.stl" target="_blank">Upper duct cpap c clamp</a> | 1 | - |
+| <a href="https://github.com/VzBoT3D/Goliath/blob/main/STL/Goliath%20fan%20shroud%202510%20for%20CNC%20Vz-Printhead.stl" target="_blank">Goliath 2510 fan shroud</a> | 1 | - |
 
 ## Step 1
 

--- a/docs/vz235_mellow/top_cover/hinges.md
+++ b/docs/vz235_mellow/top_cover/hinges.md
@@ -30,7 +30,7 @@ author: jay_s_uk
 
 | File name          | Amount to print |
 | ------------------ | --------------- |
-| [Hinge door side]  | 4               |
+| [Hinge door side]  | 2               |
 | [Hinge frame side] | 2               |
 
 ### Step 1

--- a/docs/vz235_mellow/z_assembly_bed/bed_additions.md
+++ b/docs/vz235_mellow/z_assembly_bed/bed_additions.md
@@ -30,8 +30,8 @@ permalink: /vz235_mellow/z_assembly/bed_additions
 
 | File name | Amount to print |
 |-----------|-----------------|
-| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">Chain mount</a> | 1 |
-| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">Endstop mount</a> | 1 |
+| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Z-Assembly/parts%20to%20print%20once/chain%20holder.stl" target="_blank">Chain mount</a> | 1 |
+| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Z-Assembly/parts%20to%20print%20once/z%20stop%20switch%20mount.stl" target="_blank">Endstop mount</a> | 1 |
 
 ### Step 1
 

--- a/docs/vz235_mellow/z_assembly_bed/bed_assembly.md
+++ b/docs/vz235_mellow/z_assembly_bed/bed_assembly.md
@@ -33,9 +33,9 @@ permalink: /vz235_mellow/z_assembly/bed_assembly
 
 | File name | Amount to print |
 |-----------|-----------------|
-| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">Oldham couplers ( optional )</a> | 2 | - |
-| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">LM10LUU adapter</a> | 4 | Only if you don't use the bought version |
-| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">Bed level knobs</a> | 4 | - |
+| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/tree/main/Assemblies%20%26%20STL/Z-Assembly/Oldham%20(printed)" target="_blank">Oldham couplers ( optional )</a> | 2 | - |
+| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Z-Assembly/parts%20to%20print%202%20%26%204%20times/LM10LUU%20to%20LMK10LUU.stl" target="_blank">LM10LUU adapter</a> | 4 | Only if you don't use the bought version |
+| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Z-Assembly/parts%20to%20print%202%20%26%204%20times/bed%20knob.stl" target="_blank">Bed level knobs</a> | 4 | - |
 
 ### Step 1
 

--- a/docs/vz235_printed/bottom_panels.md
+++ b/docs/vz235_printed/bottom_panels.md
@@ -31,10 +31,10 @@ A full panel kit is available at F3D-racing’s shop. We recommend getting that 
 
 ## STL's
 
-| File name                                                                                                                                                     | Amount to print |
-|---------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
-| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">VzBoT Foot</a>                      | 4               |
-| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">Foot scalable spacer (optional)</a> | 4               |
+| File name                                                                                                                                                       | Amount to print |
+|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Feet/STL/foot.stl" target="_blank">VzBoT Foot</a>                        | 4               |
+| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Feet/STL/Spacer.stl" target="_blank">Foot scalable spacer (optional)</a> | 4               |
 
 ### Step 1
 

--- a/docs/vz235_printed/gantry/y_gantry.md
+++ b/docs/vz235_printed/gantry/y_gantry.md
@@ -35,8 +35,8 @@ permalink: /vz235_printed/gantry/y_gantry
 
 | File name | Amount to print |
 |-----------|-----------------|
-| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">MGN12 alignment tool</a> | 4 |
-| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">MGN9 alignment tool</a> | 4 |
+| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Tools/mgn12%20allignment%20tool.stl" target="_blank">MGN12 alignment tool</a> | 4 |
+| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Tools/mgn9%20allignment%20tool.stl" target="_blank">MGN9 alignment tool</a> | 4 |
 | <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">Y gantry printed bottom</a> | 2 |
 | <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">Y gantry printed top</a> | 2 |
 

--- a/docs/vz235_printed/top_cover/front.md
+++ b/docs/vz235_printed/top_cover/front.md
@@ -30,11 +30,11 @@ permalink: /vz235_printed/top_cover/front
 
 | File name | Amount to print |
 |-----------|-----------------|
-| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">Latch LD</a> | 1 |
-| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">Latch RD</a> | 1 |
-| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">Latch UL</a> | 1 |
-| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">Latch UR</a> | 1 |
-| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">Latch frame side [not needed when done while assembling the frame]</a> | 4 |
+| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Enclosure/Front%20door%20latches/Magnetic%20latch/Door%20latch%20bottom%20left.stl" target="_blank">Latch BL</a> | 1 |
+| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Enclosure/Front%20door%20latches/Magnetic%20latch/Door%20latch%20top%20right.stl" target="_blank">Latch BR</a> | 1 |
+| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Enclosure/Front%20door%20latches/Magnetic%20latch/Door%20latch%20bottom%20left.stl" target="_blank">Latch TL</a> | 1 |
+| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Enclosure/Front%20door%20latches/Magnetic%20latch/Door%20latch%20bottom%20right.stl" target="_blank">Latch TR</a> | 1 |
+| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Enclosure/Front%20door%20latches/Magnetic%20latch/Door%20latch%20mount.stl" target="_blank">Latch frame side [not needed when done while assembling the frame]</a> | 4 |
 
 ### Step 1
 

--- a/docs/vz235_printed/top_cover/hinges.md
+++ b/docs/vz235_printed/top_cover/hinges.md
@@ -26,10 +26,10 @@ permalink: /vz235_printed/top_cover/hinges
 
 ## STL's
 
-| File name                                                                                                                                      | Amount to print |
-|------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
-| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">Hinge door side</a>  | 2               |
-| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">Hinge frame side</a> | 2               |
+| File name                                                                                                                                                                                       | Amount to print |
+|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Enclosure/Hinges%20(lower)/hinges%20%5Blower%5D/door%20side.stl" target="_blank">Hinge door side</a>           | 2               |
+| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Enclosure/Hinges%20(lower)/hinges%20%5Blower%5D/hinge%20frame%20side.stl" target="_blank">Hinge frame side</a> | 2               |
 
 ### Step 1
 

--- a/docs/vz235_printed/top_cover/latches.md
+++ b/docs/vz235_printed/top_cover/latches.md
@@ -32,9 +32,9 @@ permalink: /vz235_printed/top_cover/latches
 
 | File name | Amount to print |
 |-----------|-----------------|
-| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">Top cover holder top part</a> | 4 |
-| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">Top cover holder middle part</a> | 4 |
-| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Frame/Frame%20brace.stl" target="_blank">Top cover holder bottom part</a> | 4 |
+| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Enclosure/Topcover%20Latches/topcover%20latch/topcover%20holder%20top%20part%202.stl" target="_blank">Top cover holder top part</a> | 4 |
+| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Enclosure/Topcover%20Latches/topcover%20latch/topcover%20holder%20top%20part.stl" target="_blank">Top cover holder middle part</a> | 4 |
+| <a href="https://github.com/VzBoT3D/VzBoT-Vz235/blob/main/Assemblies%20%26%20STL/Enclosure/Topcover%20Latches/topcover%20latch/topcover%20holder.stl" target="_blank">Top cover holder bottom part</a> | 4 |
 
 ### Step 1
 


### PR DESCRIPTION
The beacon probe needs two spacers to be mounted for a regular Goliath hotend, so bumping the number to two.