### PR TITLE
Fix BOM for Z Motor mount of VZ235 Mellow

### DIFF
--- a/docs/vz235_mellow/z_assembly_bed/z_motor.md
+++ b/docs/vz235_mellow/z_assembly_bed/z_motor.md
@@ -19,10 +19,9 @@ permalink: /vz235_mellow/z_assembly/z_motor
 
 | Material        | Quantity | Notes |
 |:----------------|:---------|:------|
-| M3 10mm         | 6        | -     |
-| M4 10mm         | 2        | -     |
+| M3 10mm         | 4        | -     |
+| M4 10mm         | 4        | -     |
 | M4 t-nut        | 2        | -     |
-| M3 washer       | 2        | -     |
 | GT2 20 teeth    | 1        | -     |
 | NEMA 17 stepper | 1        | -     |
 


### PR DESCRIPTION
The CNC bracket requires 2 M4x10 instead of 2 M3x10 + 2 M3 washers like the 3D printed one.